### PR TITLE
Fix date format in the release version file.

### DIFF
--- a/git-push-tags.sh
+++ b/git-push-tags.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 DATE=$(date -u +'%Y-%m-%dT%H-%M-%S')
-echo date > site/RELEASE
+echo -n "$DATE" > site/RELEASE
 git commit site/RELEASE -m "$DATE"
 git tag "$DATE" -m "$DATE"
 git push --follow-tags


### PR DESCRIPTION
The RELEASE file now contains the date of the latest created tag. I think this was your intention.

But shouldn't this be done by the CI instead (and the git tagging as well)?